### PR TITLE
feat: Principais mudanças:

### DIFF
--- a/API/NETCORE/Controllers/Auth/AuthController.cs
+++ b/API/NETCORE/Controllers/Auth/AuthController.cs
@@ -19,6 +19,8 @@ public class AuthController(
     HorusJwtService jwtService,
     HorusRecaptchaService recaptchaService,
     HorusEmailService emailService,
+    HorusSecurityOptions securityOptions,
+    IWebHostEnvironment environment,
     ILogger<AuthController> logger) : ControllerBase
 {
     [HttpPost("login")]
@@ -62,13 +64,13 @@ public class AuthController(
         }
 
         var token = jwtService.CreateToken(result.User, result.Session, ip);
+        AppendAuthCookie(token, request.RememberMe);
         return Ok(new ApiResponse<object>
         {
             Success = true,
             Message = "Login realizado com sucesso.",
             Data = new
             {
-                token,
                 tokenType = "Bearer",
                 expiresInSeconds = jwtService.SessionHours * 60 * 60,
                 sessionId = result.Session.Id,
@@ -113,6 +115,16 @@ public class AuthController(
             });
         }
 
+        var emailEnabled = await emailService.IsEnabledAsync();
+        if (!emailEnabled && !environment.IsDevelopment())
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new ApiResponse<object>
+            {
+                Success = false,
+                Message = "Recuperação de senha indisponível. Configure o envio de e-mail."
+            });
+        }
+
         var ip = GetClientIp();
         var userAgent = Request.Headers.UserAgent.ToString();
         var resetRequest = securityStore.CreatePasswordResetToken(request.Cnpj, request.Email, ip, userAgent);
@@ -144,7 +156,7 @@ public class AuthController(
         {
             Success = true,
             Message = "Se o e-mail estiver cadastrado, enviaremos as instruções de recuperação.",
-            Data = await emailService.IsEnabledAsync()
+            Data = emailEnabled || !environment.IsDevelopment()
                 ? new
                 {
                     resetRequest.Accepted,
@@ -181,6 +193,7 @@ public class AuthController(
                 request.ConfirmPassword,
                 GetClientIp(),
                 Request.Headers.UserAgent.ToString());
+            DeleteAuthCookie();
             return Ok(new ApiResponse<object>
             {
                 Success = true,
@@ -303,6 +316,7 @@ public class AuthController(
             securityStore.TerminateCurrentSession(currentUser.SessionId);
         }
 
+        DeleteAuthCookie();
         return Ok(new ApiResponse<object>
         {
             Success = true,
@@ -343,15 +357,31 @@ public class AuthController(
     }
 
     private string GetClientIp()
+        => HorusClientIpResolver.Resolve(HttpContext, securityOptions, "0.0.0.0");
+
+    private void AppendAuthCookie(string token, bool rememberMe)
     {
-        var forwarded = Request.Headers["X-Forwarded-For"].FirstOrDefault();
-        if (!string.IsNullOrWhiteSpace(forwarded))
+        var options = BuildAuthCookieOptions();
+        if (rememberMe)
         {
-            return forwarded.Split(',')[0].Trim();
+            options.Expires = DateTimeOffset.UtcNow.AddHours(jwtService.SessionHours);
         }
 
-        return HttpContext.Connection.RemoteIpAddress?.ToString() ?? "0.0.0.0";
+        Response.Cookies.Append(HorusJwtService.AuthCookieName, token, options);
     }
+
+    private void DeleteAuthCookie()
+    {
+        Response.Cookies.Delete(HorusJwtService.AuthCookieName, BuildAuthCookieOptions());
+    }
+
+    private CookieOptions BuildAuthCookieOptions() => new()
+    {
+        HttpOnly = true,
+        Secure = !environment.IsDevelopment(),
+        SameSite = environment.IsDevelopment() ? SameSiteMode.Lax : SameSiteMode.Strict,
+        Path = "/"
+    };
 
     public class UpdateProfileRequest
     {

--- a/API/NETCORE/Controllers/Usuario/UsuarioController.cs
+++ b/API/NETCORE/Controllers/Usuario/UsuarioController.cs
@@ -6,6 +6,7 @@
 using HORUSPDV_API.Models.Requests;
 using HORUSPDV_API.Models.Response;
 using HORUSPDV_API.Repositories.DatabaseAccess;
+using HORUSPDV_API.Services.Email;
 using HORUSPDV_API.Services.Security;
 using Microsoft.AspNetCore.Mvc;
 
@@ -14,7 +15,11 @@ namespace HORUSPDV_API.Controllers.Usuario;
 [ApiController]
 [Route("api/[controller]")]
 [HorusAuthorizeRoles("administrador", "gerente")]
-public class UsuarioController(HorusSecurityStore securityStore) : ControllerBase
+public class UsuarioController(
+    HorusSecurityStore securityStore,
+    HorusEmailService emailService,
+    IWebHostEnvironment environment,
+    ILogger<UsuarioController> logger) : ControllerBase
 {
     [HttpGet]
     public IActionResult Listar()
@@ -112,7 +117,7 @@ public class UsuarioController(HorusSecurityStore securityStore) : ControllerBas
     }
 
     [HttpPost("{id}/resetar-senha")]
-    public IActionResult ResetarSenha(string id)
+    public async Task<IActionResult> ResetarSenha(string id)
     {
         var currentUser = GetCurrentUser();
         if (currentUser is null)
@@ -120,17 +125,68 @@ public class UsuarioController(HorusSecurityStore securityStore) : ControllerBas
             return Unauthorized(new ApiResponse<object> { Success = false, Message = "Sessão não encontrada." });
         }
 
-        var result = securityStore.ResetPassword(id, currentUser.CompanyId);
+        var emailEnabled = await emailService.IsEnabledAsync();
+        if (!emailEnabled && !environment.IsDevelopment())
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new ApiResponse<object>
+            {
+                Success = false,
+                Message = "Reset de senha indisponível. Configure o envio de e-mail."
+            });
+        }
+
+        var result = securityStore.CreateAdminPasswordResetToken(
+            id,
+            currentUser.CompanyId,
+            GetClientIp(),
+            Request.Headers.UserAgent.ToString());
         if (result is null)
         {
             return NotFound(new ApiResponse<object> { Success = false, Message = "Usuário não encontrado." });
         }
 
+        if (!string.IsNullOrWhiteSpace(result.ResetToken) && result.ExpiresAt is not null && emailEnabled)
+        {
+            var resetUrl = emailService.BuildPasswordResetUrl(result.ResetToken);
+            try
+            {
+                await emailService.SendPasswordResetEmailAsync(
+                    result.User.Email,
+                    "Hórus PDV",
+                    resetUrl,
+                    result.ExpiresAt.Value,
+                    HttpContext.RequestAborted);
+            }
+            catch (Exception ex)
+            {
+                securityStore.ConsumePasswordResetToken(
+                    result.ResetToken,
+                    GetClientIp(),
+                    Request.Headers.UserAgent.ToString());
+                logger.LogWarning(ex, "Não foi possível enviar e-mail de reset administrativo para {Email}.", result.User.Email);
+                return StatusCode(StatusCodes.Status502BadGateway, new ApiResponse<object>
+                {
+                    Success = false,
+                    Message = "Não foi possível enviar o e-mail de redefinição de senha."
+                });
+            }
+        }
+
+        object responseData = emailEnabled || !environment.IsDevelopment()
+            ? new
+            {
+                result.User,
+                result.Accepted,
+                result.MaskedEmail,
+                result.ExpiresAt
+            }
+            : result;
+
         return Ok(new ApiResponse<object>
         {
             Success = true,
-            Message = "Senha resetada com sucesso.",
-            Data = new { user = result.User, password = result.Password }
+            Message = "Redefinição de senha gerada com sucesso.",
+            Data = responseData
         });
     }
 
@@ -141,4 +197,10 @@ public class UsuarioController(HorusSecurityStore securityStore) : ControllerBas
 
     private AuthenticatedUser? GetCurrentUser()
         => HttpContext.Items["CurrentUser"] as AuthenticatedUser;
+
+    private string GetClientIp()
+    {
+        var securityOptions = HttpContext.RequestServices.GetRequiredService<HorusSecurityOptions>();
+        return HorusClientIpResolver.Resolve(HttpContext, securityOptions, "0.0.0.0");
+    }
 }

--- a/API/NETCORE/Middlewares/HorusAuthMiddleware.cs
+++ b/API/NETCORE/Middlewares/HorusAuthMiddleware.cs
@@ -19,11 +19,7 @@ public class HorusAuthMiddleware(RequestDelegate next)
             return;
         }
 
-        var authHeader = context.Request.Headers.Authorization.ToString();
-        var parts = authHeader.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        var token = parts.Length == 2 && parts[0].Equals("Bearer", StringComparison.Ordinal)
-            ? parts[1]
-            : "";
+        var token = ResolveToken(context);
 
         var authenticatedUser = string.IsNullOrWhiteSpace(token) ? null : jwtService.ValidateToken(token);
         if (authenticatedUser is null ||
@@ -64,6 +60,22 @@ public class HorusAuthMiddleware(RequestDelegate next)
                path.StartsWith("/api/Auth/forgot-password", StringComparison.OrdinalIgnoreCase) ||
                path.StartsWith("/api/Auth/reset-password", StringComparison.OrdinalIgnoreCase) ||
                path.StartsWith("/api/Auth/register", StringComparison.OrdinalIgnoreCase) ||
-               path.StartsWith("/swagger", StringComparison.OrdinalIgnoreCase);
+               (context.RequestServices.GetRequiredService<IWebHostEnvironment>().IsDevelopment() &&
+                path.StartsWith("/swagger", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string ResolveToken(HttpContext context)
+    {
+        var cookieToken = context.Request.Cookies[HorusJwtService.AuthCookieName];
+        if (!string.IsNullOrWhiteSpace(cookieToken))
+        {
+            return cookieToken;
+        }
+
+        var authHeader = context.Request.Headers.Authorization.ToString();
+        var parts = authHeader.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return parts.Length == 2 && parts[0].Equals("Bearer", StringComparison.Ordinal)
+            ? parts[1]
+            : "";
     }
 }

--- a/API/NETCORE/Middlewares/HorusRateLimitMiddleware.cs
+++ b/API/NETCORE/Middlewares/HorusRateLimitMiddleware.cs
@@ -22,7 +22,7 @@ public class HorusRateLimitMiddleware(RequestDelegate next)
         }
 
         var now = DateTimeOffset.UtcNow;
-        var key = ResolveClientIp(context);
+        var key = HorusClientIpResolver.Resolve(context, securityOptions);
         var window = TimeSpan.FromSeconds(securityOptions.RequestRateLimitWindowSeconds);
         var bucket = Buckets.AddOrUpdate(
             key,
@@ -61,17 +61,6 @@ public class HorusRateLimitMiddleware(RequestDelegate next)
 
     private static bool IsSwagger(string? path)
         => !string.IsNullOrWhiteSpace(path) && path.StartsWith("/swagger", StringComparison.OrdinalIgnoreCase);
-
-    private static string ResolveClientIp(HttpContext context)
-    {
-        var forwarded = context.Request.Headers["X-Forwarded-For"].FirstOrDefault();
-        if (!string.IsNullOrWhiteSpace(forwarded))
-        {
-            return forwarded.Split(',')[0].Trim();
-        }
-
-        return context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
-    }
 
     private static void CleanupExpired(DateTimeOffset now)
     {

--- a/API/NETCORE/Middlewares/HorusRequestTelemetryMiddleware.cs
+++ b/API/NETCORE/Middlewares/HorusRequestTelemetryMiddleware.cs
@@ -9,7 +9,7 @@ namespace HORUSPDV_API.Middlewares;
 
 public class HorusRequestTelemetryMiddleware(RequestDelegate next, ILogger<HorusRequestTelemetryMiddleware> logger)
 {
-    public async Task InvokeAsync(HttpContext context)
+    public async Task InvokeAsync(HttpContext context, HorusSecurityOptions securityOptions)
     {
         var requestId = Guid.NewGuid().ToString("N");
         var startedAt = DateTimeOffset.UtcNow;
@@ -33,18 +33,7 @@ public class HorusRequestTelemetryMiddleware(RequestDelegate next, ILogger<Horus
                 Math.Round(durationMs),
                 currentUser?.Id,
                 currentUser?.SessionId,
-                ResolveClientIp(context));
+                HorusClientIpResolver.Resolve(context, securityOptions));
         }
-    }
-
-    private static string ResolveClientIp(HttpContext context)
-    {
-        var forwarded = context.Request.Headers["X-Forwarded-For"].FirstOrDefault();
-        if (!string.IsNullOrWhiteSpace(forwarded))
-        {
-            return forwarded.Split(',')[0].Trim();
-        }
-
-        return context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
     }
 }

--- a/API/NETCORE/Program.cs
+++ b/API/NETCORE/Program.cs
@@ -31,7 +31,8 @@ builder.Services.AddCors(options =>
         policyBuilder
             .WithOrigins(corsOrigins)
             .AllowAnyHeader()
-            .AllowAnyMethod();
+            .AllowAnyMethod()
+            .AllowCredentials();
     });
 });
 
@@ -96,8 +97,11 @@ app.UseMiddleware<HorusRateLimitMiddleware>();
 app.UseMiddleware<HorusAuthMiddleware>();
 app.UseAuthorization();
 
-app.UseSwagger();
-app.UseSwaggerUI();
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
 
 app.MapControllers();
 

--- a/API/NETCORE/README.md
+++ b/API/NETCORE/README.md
@@ -23,11 +23,15 @@ Suba o SQL Server via Docker:
   mcr.microsoft.com/mssql/server:2022-latest
 </code></pre>
 
-Connection string padrão:
+Connection string local de desenvolvimento:
 
 <pre><code class="language-json">"ConnectionStrings": {
   "HorusPdv": "Server=localhost,1433;Database=HorusPdv;User Id=sa;Password=Senha@12345;TrustServerCertificate=True;Encrypt=True;MultipleActiveResultSets=True"
 }</code></pre>
+
+Se seu container estiver publicado em outra porta, ajuste o host da connection string local. Exemplo: `docker ps` mostrando `0.0.0.0:1434->1433/tcp` exige `Server=localhost,1434`.
+
+Não use essa senha em produção. Para ambientes publicados, configure a conexão fora do repositório, por exemplo com `HORUSPDV_CONNECTION_STRING` ou o secret manager da hospedagem.
 
 Ao iniciar, a API executa `DataBase/Resumo.sql` para criar o banco `HorusPdv`, criar tabelas/relacionamentos e inserir os dados iniciais quando ainda não existirem.
 
@@ -50,14 +54,14 @@ dotnet user-secrets set "Email:Enabled" "true"
 dotnet user-secrets set "Email:Password" "SUA_SENHA_DE_APP_AQUI"
 </code></pre>
 
-Configurações padrão em `appsettings.json`:
+Configurações de exemplo:
 
 <pre><code class="language-json">"Email": {
   "Host": "smtp-mail.outlook.com",
   "Port": 587,
   "User": "naoresponderhoruspdv@outlook.com",
   "FromEmail": "naoresponderhoruspdv@outlook.com",
-  "FrontendBaseUrl": "http://localhost:5173"
+  "FrontendBaseUrl": "https://seu-frontend.example.com"
 }</code></pre>
 
 Para conta `@outlook.com`, o host padrão é `smtp-mail.outlook.com`, porta `587`, com STARTTLS. Para conta Microsoft 365 corporativa, use `smtp.office365.com`.
@@ -66,9 +70,9 @@ Se o envio SMTP retornar `SmtpClientAuthentication is disabled for the Mailbox`,
 
 Em operação, a configuração principal fica em `Minha Empresa > Configuração de e-mail`, salva na tabela `Empresas`. Quando ela estiver ativa, os disparos usam o SMTP da empresa; quando estiver desativada, a API usa o fallback de `appsettings`/User Secrets para desenvolvimento. A senha SMTP não é devolvida pela API, apenas o indicador de senha configurada.
 
-A senha SMTP é gravada criptografada no banco. Em produção, configure uma chave forte:
+A senha SMTP é gravada criptografada no banco. Em produção, configure uma chave forte por variável de ambiente ou secret manager:
 
-<pre><code class="language-bash">dotnet user-secrets set "Security:EncryptionKey" "UMA_CHAVE_FORTE_COM_PELO_MENOS_32_CARACTERES"
+<pre><code class="language-bash">Security__EncryptionKey="UMA_CHAVE_FORTE_COM_PELO_MENOS_32_CARACTERES"
 </code></pre>
 
 Exemplo para Gmail, se você decidir usar uma caixa Gmail no futuro:
@@ -93,7 +97,7 @@ dotnet build
 dotnet run --urls http://localhost:5260
 </code></pre>
 
-Swagger:
+Swagger fica disponível apenas em ambiente `Development`:
 
 <pre><code class="language-text">http://localhost:5260/swagger
 </code></pre>

--- a/API/NETCORE/Repositories/Connection.cs
+++ b/API/NETCORE/Repositories/Connection.cs
@@ -9,9 +9,6 @@ namespace HORUSPDV_API.Repositories;
 
 public sealed class Connection(IConfiguration configuration)
 {
-    private const string DefaultConnectionString =
-        "Server=localhost,1433;Database=HorusPdv;User Id=sa;Password=Senha@12345;TrustServerCertificate=True;Encrypt=True;MultipleActiveResultSets=True;Pooling=True;Min Pool Size=5;Max Pool Size=100;Connection Timeout=30;";
-
     public string ConnectionString { get; } = ResolveConnectionString(configuration);
 
     public async Task<SqlConnection> OpenConnectionAsync(
@@ -46,10 +43,24 @@ public sealed class Connection(IConfiguration configuration)
     }
 
     private static string ResolveConnectionString(IConfiguration configuration)
-        => configuration.GetConnectionString("HorusPdv")
-           ?? configuration.GetConnectionString("DefaultConnection")
-           ?? Environment.GetEnvironmentVariable("SQLCONNSTR_HorusPdv")
-           ?? Environment.GetEnvironmentVariable("SQLCONNSTR_DefaultConnection")
-           ?? Environment.GetEnvironmentVariable("HORUSPDV_CONNECTION_STRING")
-           ?? DefaultConnectionString;
+    {
+        var connectionString =
+            FirstNonEmpty(
+                configuration.GetConnectionString("HorusPdv"),
+                configuration.GetConnectionString("DefaultConnection"),
+                Environment.GetEnvironmentVariable("SQLCONNSTR_HorusPdv"),
+                Environment.GetEnvironmentVariable("SQLCONNSTR_DefaultConnection"),
+                Environment.GetEnvironmentVariable("HORUSPDV_CONNECTION_STRING"));
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException(
+                "Connection string não configurada. Defina ConnectionStrings:HorusPdv ou HORUSPDV_CONNECTION_STRING.");
+        }
+
+        return connectionString;
+    }
+
+    private static string? FirstNonEmpty(params string?[] values)
+        => values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
 }

--- a/API/NETCORE/Repositories/DatabaseAccess/HorusSecurityStore.cs
+++ b/API/NETCORE/Repositories/DatabaseAccess/HorusSecurityStore.cs
@@ -152,41 +152,6 @@ public class HorusSecurityStore(Connection connection, HorusSecurityOptions secu
         return ToDto(updated);
     }
 
-    public ResetPasswordResult? ResetPassword(string id, string companyId)
-    {
-        var user = FindUserById(id, companyId);
-        if (user is null) return null;
-
-        var password = $"Tmp@{Random.Shared.Next(100000, 999999)}9";
-        using var db = connection.OpenConnection();
-        using var transaction = db.BeginTransaction();
-        try
-        {
-            using var command = new SqlCommand(
-                """
-                UPDATE Usuarios
-                   SET PasswordHash = @PasswordHash,
-                       MustChangePassword = 1
-                 WHERE Id = @Id;
-                DELETE FROM Sessoes WHERE UserId = @Id;
-                """,
-                db,
-                transaction);
-            command.Parameters.AddWithValue("@PasswordHash", PasswordHasher.Hash(password));
-            command.Parameters.AddWithValue("@Id", user.Id);
-            command.ExecuteNonQuery();
-            transaction.Commit();
-        }
-        catch
-        {
-            transaction.Rollback();
-            throw;
-        }
-
-        user.MustChangePassword = true;
-        return new ResetPasswordResult(ToDto(user), password);
-    }
-
     public LoginResult Authenticate(string email, string password, string ip, string userAgent)
     {
         var normalizedEmail = email.Trim().ToLowerInvariant();
@@ -411,6 +376,106 @@ public class HorusSecurityStore(Connection connection, HorusSecurityOptions secu
 
             transaction.Commit();
             return PasswordResetRequestResult.Create(MaskEmail(user.Email), token, expiresAt);
+        }
+        catch
+        {
+            transaction.Rollback();
+            throw;
+        }
+    }
+
+    public AdminPasswordResetResult? CreateAdminPasswordResetToken(
+        string userId,
+        string companyId,
+        string ip,
+        string userAgent)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var expiresAt = now.AddMinutes(securityOptions.PasswordResetTokenMinutes);
+        var requestedDevice = BuildDeviceLabel(userAgent);
+
+        using var db = connection.OpenConnection();
+        using var transaction = db.BeginTransaction();
+        try
+        {
+            var user = FindUserById(db, transaction, userId, companyId);
+            if (user is null) return null;
+
+            var cnpj = FindCompanyCnpj(db, transaction, companyId);
+
+            using (var cleanup = new SqlCommand(
+                       "DELETE FROM PasswordResetTokens WHERE ExpiresAt <= @RetentionCutoff;",
+                       db,
+                       transaction))
+            {
+                cleanup.Parameters.AddWithValue("@RetentionCutoff", now.AddDays(-7));
+                cleanup.ExecuteNonQuery();
+            }
+
+            using (var deleteTokens = new SqlCommand(
+                       """
+                       UPDATE PasswordResetTokens
+                          SET ConsumedAt = @Now,
+                              UpdatedAt = @Now
+                        WHERE UserId = @UserId
+                          AND ConsumedAt IS NULL;
+                       """,
+                       db,
+                       transaction))
+            {
+                deleteTokens.Parameters.AddWithValue("@UserId", user.Id);
+                deleteTokens.Parameters.AddWithValue("@Now", now);
+                deleteTokens.ExecuteNonQuery();
+            }
+
+            var token = GenerateSecureToken();
+            var tokenHash = HashPasswordResetToken(token);
+            using (var insert = new SqlCommand(
+                       """
+                       INSERT INTO PasswordResetTokens
+                           (Id, UserId, Email, Cnpj, TokenHash, CreatedAt, RequestedAt, ExpiresAt, ConsumedAt,
+                            RequestedIp, RequestedUserAgent, RequestedDevice, ResetIp, ResetUserAgent, ResetDevice, UpdatedAt)
+                       VALUES
+                           (@Id, @UserId, @Email, @Cnpj, @TokenHash, @CreatedAt, @RequestedAt, @ExpiresAt, NULL,
+                            @RequestedIp, @RequestedUserAgent, @RequestedDevice, NULL, NULL, NULL, @UpdatedAt);
+                       """,
+                       db,
+                       transaction))
+            {
+                insert.Parameters.AddWithValue("@Id", $"prt-{Guid.NewGuid():N}");
+                insert.Parameters.AddWithValue("@UserId", user.Id);
+                insert.Parameters.AddWithValue("@Email", user.Email);
+                insert.Parameters.AddWithValue("@Cnpj", cnpj);
+                insert.Parameters.AddWithValue("@TokenHash", tokenHash);
+                insert.Parameters.AddWithValue("@CreatedAt", now);
+                insert.Parameters.AddWithValue("@RequestedAt", now);
+                insert.Parameters.AddWithValue("@ExpiresAt", expiresAt);
+                insert.Parameters.AddWithValue("@RequestedIp", NullIfEmpty(ip));
+                insert.Parameters.AddWithValue("@RequestedUserAgent", NullIfEmpty(userAgent));
+                insert.Parameters.AddWithValue("@RequestedDevice", NullIfEmpty(requestedDevice));
+                insert.Parameters.AddWithValue("@UpdatedAt", now);
+                insert.ExecuteNonQuery();
+            }
+
+            using (var updateUser = new SqlCommand(
+                       "UPDATE Usuarios SET MustChangePassword = 1 WHERE Id = @UserId AND CompanyId = @CompanyId;",
+                       db,
+                       transaction))
+            {
+                updateUser.Parameters.AddWithValue("@UserId", user.Id);
+                updateUser.Parameters.AddWithValue("@CompanyId", companyId);
+                updateUser.ExecuteNonQuery();
+            }
+
+            using (var deleteSessions = new SqlCommand("DELETE FROM Sessoes WHERE UserId = @UserId;", db, transaction))
+            {
+                deleteSessions.Parameters.AddWithValue("@UserId", user.Id);
+                deleteSessions.ExecuteNonQuery();
+            }
+
+            transaction.Commit();
+            user.MustChangePassword = true;
+            return AdminPasswordResetResult.Create(ToDto(user), MaskEmail(user.Email), token, expiresAt);
         }
         catch
         {
@@ -678,8 +743,7 @@ public class HorusSecurityStore(Connection connection, HorusSecurityOptions secu
     private SecurityUserRecord? FindUserById(string id, string companyId)
     {
         using var db = connection.OpenConnection();
-        var user = FindUserById(db, null, id);
-        return user is not null && user.CompanyId == companyId ? user : null;
+        return FindUserById(db, null, id, companyId);
     }
 
     private SecurityUserRecord? FindUserByEmail(string email)
@@ -710,6 +774,34 @@ public class HorusSecurityStore(Connection connection, HorusSecurityOptions secu
         command.Parameters.AddWithValue("@Id", id);
         using var reader = command.ExecuteReader();
         return reader.Read() ? ReadUser(reader) : null;
+    }
+
+    private static SecurityUserRecord? FindUserById(
+        SqlConnection db,
+        SqlTransaction? transaction,
+        string id,
+        string companyId)
+    {
+        using var command = new SqlCommand(
+            """
+            SELECT Id, CompanyId, Cpf, Name, Email, Phone, Role, Status, CreatedAt, LastLoginAt, PasswordHash, MustChangePassword
+            FROM Usuarios
+            WHERE Id = @Id AND CompanyId = @CompanyId;
+            """,
+            db,
+            transaction);
+        command.Parameters.AddWithValue("@Id", id);
+        command.Parameters.AddWithValue("@CompanyId", companyId);
+        using var reader = command.ExecuteReader();
+        return reader.Read() ? ReadUser(reader) : null;
+    }
+
+    private static string FindCompanyCnpj(SqlConnection db, SqlTransaction transaction, string companyId)
+    {
+        using var command = new SqlCommand("SELECT Cnpj FROM Empresas WHERE Id = @CompanyId;", db, transaction);
+        command.Parameters.AddWithValue("@CompanyId", companyId);
+        var result = command.ExecuteScalar()?.ToString() ?? "";
+        return OnlyDigits(result);
     }
 
     private static SecurityUserRecord? FindUserForPasswordReset(
@@ -944,11 +1036,25 @@ public class SecuritySessionDto
     public string Platform { get; set; } = "desktop";
 }
 
-public record ResetPasswordResult(SecurityUserDto User, string Password);
 public record PasswordResetRequestResult(bool Accepted, string? MaskedEmail, string? ResetToken, DateTimeOffset? ExpiresAt)
 {
     public static PasswordResetRequestResult Create(string? maskedEmail = null, string? resetToken = null, DateTimeOffset? expiresAt = null)
         => new(true, maskedEmail, resetToken, expiresAt);
+}
+
+public record AdminPasswordResetResult(
+    SecurityUserDto User,
+    bool Accepted,
+    string? MaskedEmail,
+    string? ResetToken,
+    DateTimeOffset? ExpiresAt)
+{
+    public static AdminPasswordResetResult Create(
+        SecurityUserDto user,
+        string? maskedEmail,
+        string? resetToken,
+        DateTimeOffset? expiresAt)
+        => new(user, true, maskedEmail, resetToken, expiresAt);
 }
 
 public record LoginResult(bool Success, string Message, SecurityUserDto? User, SecuritySession? Session, DateTimeOffset? LockedUntil)

--- a/API/NETCORE/Services/Security/HorusClientIpResolver.cs
+++ b/API/NETCORE/Services/Security/HorusClientIpResolver.cs
@@ -1,0 +1,23 @@
+/**
+ * Arquivo: API/NETCORE/Services/Security/HorusClientIpResolver.cs
+ * Objetivo: resolver IP do cliente sem confiar em cabeçalhos de proxy por padrão.
+ * Entradas esperadas: recebe HttpContext e opções de segurança para auditar e limitar requisições.
+ */
+namespace HORUSPDV_API.Services.Security;
+
+public static class HorusClientIpResolver
+{
+    public static string Resolve(HttpContext context, HorusSecurityOptions securityOptions, string fallback = "unknown")
+    {
+        if (securityOptions.TrustForwardedHeaders)
+        {
+            var forwarded = context.Request.Headers["X-Forwarded-For"].FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(forwarded))
+            {
+                return forwarded.Split(',')[0].Trim();
+            }
+        }
+
+        return context.Connection.RemoteIpAddress?.ToString() ?? fallback;
+    }
+}

--- a/API/NETCORE/Services/Security/HorusJwtService.cs
+++ b/API/NETCORE/Services/Security/HorusJwtService.cs
@@ -12,6 +12,8 @@ namespace HORUSPDV_API.Services.Security;
 
 public class HorusJwtService(HorusSecurityOptions securityOptions)
 {
+    public const string AuthCookieName = "horuspdv.auth";
+
     public int SessionHours => securityOptions.SessionHours;
 
     public string CreateToken(SecurityUserDto user, SecuritySession session, string ip)

--- a/API/NETCORE/Services/Security/HorusSecurityOptions.cs
+++ b/API/NETCORE/Services/Security/HorusSecurityOptions.cs
@@ -7,8 +7,7 @@ namespace HORUSPDV_API.Services.Security;
 
 public class HorusSecurityOptions(IConfiguration configuration, IWebHostEnvironment environment)
 {
-    public string JwtSecret { get; } = configuration["Auth:JwtSecret"]
-        ?? "horus-pdv-development-secret-change-before-production-2026";
+    public string JwtSecret { get; } = configuration["Auth:JwtSecret"] ?? "";
 
     public string EncryptionKey { get; } = configuration["Security:EncryptionKey"] ?? "";
 
@@ -51,12 +50,15 @@ public class HorusSecurityOptions(IConfiguration configuration, IWebHostEnvironm
             ? Math.Clamp(maxBodyBytes, 32_768, 25_000_000)
             : 2_000_000;
 
+    public bool TrustForwardedHeaders { get; } =
+        bool.TryParse(configuration["Security:TrustForwardedHeaders"], out var trustForwardedHeaders) &&
+        trustForwardedHeaders;
+
     public void Validate()
     {
         if (!environment.IsProduction()) return;
 
-        var usingDefault = JwtSecret == "horus-pdv-development-secret-change-before-production-2026";
-        if (usingDefault || JwtSecret.Length < 32)
+        if (string.IsNullOrWhiteSpace(JwtSecret) || JwtSecret.Length < 32)
         {
             throw new InvalidOperationException(
                 "Auth:JwtSecret invalido em producao. Defina um segredo forte com pelo menos 32 caracteres.");

--- a/API/NETCORE/appsettings.Development.json
+++ b/API/NETCORE/appsettings.Development.json
@@ -1,4 +1,41 @@
 {
+  "ConnectionStrings": {
+    "HorusPdv": "Server=localhost,1433;Database=HorusPdv;User Id=sa;Password=Senha@12345;TrustServerCertificate=True;Encrypt=True;MultipleActiveResultSets=True"
+  },
+  "Auth": {
+    "JwtSecret": "horus-pdv-development-secret-change-before-production-2026",
+    "Issuer": "horus-pdv-api",
+    "Audience": "horus-pdv-web",
+    "SessionHours": 8,
+    "PasswordResetTokenMinutes": 30
+  },
+  "Recaptcha": {
+    "Enabled": false,
+    "SecretKey": "",
+    "MinScore": 0.5
+  },
+  "Email": {
+    "Enabled": true,
+    "Host": "smtp-mail.outlook.com",
+    "Port": 587,
+    "EnableSsl": true,
+    "User": "naoresponderhoruspdv@outlook.com",
+    "Password": "",
+    "FromEmail": "naoresponderhoruspdv@outlook.com",
+    "FromName": "Hórus PDV",
+    "ReplyTo": "",
+    "FrontendBaseUrl": "http://localhost:5173"
+  },
+  "Security": {
+    "EncryptionKey": "horus-pdv-development-encryption-key-change-before-production-2026",
+    "CorsOrigins": "http://localhost:5173,https://localhost:5173,http://127.0.0.1:5173,https://127.0.0.1:5173,http://localhost:4173,https://localhost:4173,http://127.0.0.1:4173,https://127.0.0.1:4173",
+    "TrustForwardedHeaders": false,
+    "MaxRequestBodyBytes": 2000000,
+    "RateLimit": {
+      "WindowSeconds": 60,
+      "MaxRequests": 240
+    }
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/API/NETCORE/appsettings.json
+++ b/API/NETCORE/appsettings.json
@@ -1,21 +1,18 @@
 {
-  "ConnectionStrings": {
-    "HorusPdv": "Server=localhost,1433;Database=HorusPdv;User Id=sa;Password=Senha@12345;TrustServerCertificate=True;Encrypt=True;MultipleActiveResultSets=True"
-  },
   "Auth": {
-    "JwtSecret": "horus-pdv-development-secret-change-before-production-2026",
+    "JwtSecret": "",
     "Issuer": "horus-pdv-api",
     "Audience": "horus-pdv-web",
     "SessionHours": 8,
     "PasswordResetTokenMinutes": 30
   },
   "Recaptcha": {
-    "Enabled": false,
+    "Enabled": true,
     "SecretKey": "",
     "MinScore": 0.5
   },
   "Email": {
-    "Enabled": true,
+    "Enabled": false,
     "Host": "smtp-mail.outlook.com",
     "Port": 587,
     "EnableSsl": true,
@@ -24,11 +21,12 @@
     "FromEmail": "naoresponderhoruspdv@outlook.com",
     "FromName": "Hórus PDV",
     "ReplyTo": "",
-    "FrontendBaseUrl": "http://localhost:5173"
+    "FrontendBaseUrl": ""
   },
   "Security": {
-    "EncryptionKey": "horus-pdv-development-encryption-key-change-before-production-2026",
-    "CorsOrigins": "http://localhost:5173,https://localhost:5173,http://127.0.0.1:5173,https://127.0.0.1:5173,http://localhost:4173,https://localhost:4173,http://127.0.0.1:4173,https://127.0.0.1:4173",
+    "EncryptionKey": "",
+    "CorsOrigins": "",
+    "TrustForwardedHeaders": false,
     "MaxRequestBodyBytes": 2000000,
     "RateLimit": {
       "WindowSeconds": 60,

--- a/FRONTEND/playwright.config.ts
+++ b/FRONTEND/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const appUrl = process.env.SMOKE_APP_URL ?? "http://127.0.0.1:5173";
+const appUrl = process.env.SMOKE_APP_URL ?? "http://localhost:5173";
 
 export default defineConfig({
   testDir: "./tests/smoke",
@@ -32,7 +32,7 @@ export default defineConfig({
       timeout: 120_000,
     },
     {
-      command: "vite --mode development --host 127.0.0.1 --port 5173",
+      command: "vite --mode development --host localhost --port 5173",
       url: appUrl,
       reuseExistingServer: true,
       timeout: 120_000,

--- a/FRONTEND/src/App.tsx
+++ b/FRONTEND/src/App.tsx
@@ -19,9 +19,7 @@ import { authService } from "@/services/api/authService";
 import { cashRegisterService } from "@/services/api/cashRegisterService";
 import {
   clearAuthSession,
-  getAuthToken,
   getStoredAuthUser,
-  isTokenExpired,
   setAuthSession,
   type AuthenticatedUser,
 } from "@/utils/authStorage";
@@ -152,8 +150,12 @@ export default function App() {
   });
   const [isAuthenticated, setIsAuthenticated] = useState(() => {
     if (typeof window === "undefined") return false;
-    const token = getAuthToken();
-    return Boolean(token && !isTokenExpired(token) && getStoredAuthUser());
+    return Boolean(getStoredAuthUser());
+  });
+  const [isCheckingAuth, setIsCheckingAuth] = useState(() => {
+    if (typeof window === "undefined") return false;
+    const params = new URLSearchParams(window.location.search);
+    return !(params.get("resetToken") || params.get("token"));
   });
 
   const [currentUser, setCurrentUser] = useState<CurrentUser>(() => {
@@ -312,8 +314,7 @@ export default function App() {
         return { success: false, message: "A API não retornou o perfil atualizado." };
       }
 
-      const token = getAuthToken();
-      if (token) setAuthSession(token, user);
+      setAuthSession(user);
       setCurrentUser(toCurrentUser(user));
       return { success: true, message: "Perfil atualizado com sucesso." };
     } catch (error) {
@@ -409,7 +410,7 @@ export default function App() {
         };
       }
 
-      setAuthSession(result.token, result.user, remember);
+      setAuthSession(result.user, remember);
       setCurrentUser(toCurrentUser(result.user));
       setIsAuthenticated(true);
       setActivePage(isStandalonePos ? "vendas" : "home");
@@ -506,34 +507,36 @@ export default function App() {
   };
 
   useEffect(() => {
-    if (!isAuthenticated) return;
     authService
       .me()
       .then((user) => {
-        if (!user) return;
-        const token = getAuthToken();
-        if (token) setAuthSession(token, user);
+        if (!user) {
+          clearAuthSession();
+          setIsAuthenticated(false);
+          return;
+        }
+
+        setAuthSession(user);
         setCurrentUser(toCurrentUser(user));
+        setIsAuthenticated(true);
       })
       .catch(() => {
         clearAuthSession();
         setIsAuthenticated(false);
+      })
+      .finally(() => {
+        setIsCheckingAuth(false);
       });
-  }, [isAuthenticated]);
+  }, []);
 
   useEffect(() => {
     const syncAuthState = () => {
-      const token = getAuthToken();
-      if (!token || isTokenExpired(token)) {
-        clearAuthSession();
-        setIsAuthenticated(false);
-        return;
-      }
-
       const user = getStoredAuthUser();
       if (user) {
         setCurrentUser(toCurrentUser(user));
         setIsAuthenticated(true);
+      } else {
+        setIsAuthenticated(false);
       }
     };
 
@@ -573,6 +576,14 @@ export default function App() {
     }
     document.title = "Hórus PDV - PDV grátis e frente de caixa";
   }, [activePage, isStandalonePos]);
+
+  if (isCheckingAuth) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-bg-primary text-text-secondary">
+        <LoadingBar />
+      </div>
+    );
+  }
 
   if (!isAuthenticated) {
     if (publicAuthPage === "forgot-password") {

--- a/FRONTEND/src/pages/Admin/UserAccountsPage.tsx
+++ b/FRONTEND/src/pages/Admin/UserAccountsPage.tsx
@@ -165,7 +165,7 @@ export default function UserAccountsPage() {
 
   const resetPassword = async (user: AdminUser) => {
     const confirmed = await statusDialog.confirm(
-      `Resetar senha de ${user.name} para uma senha provisória?`,
+      `Gerar redefinição de senha para ${user.name}?`,
     );
     if (!confirmed) return;
 
@@ -174,7 +174,11 @@ export default function UserAccountsPage() {
       const result = await userService.resetPassword(user.id);
       if (!result) return;
       setUsers((current) => current.map((item) => (item.id === user.id ? result.user : item)));
-      statusDialog.success(`Senha de ${user.name} resetada. Senha provisória: ${result.password}`);
+      statusDialog.success(
+        result.resetToken
+          ? `Redefinição gerada para ${user.name}. Token de desenvolvimento: ${result.resetToken}`
+          : `Redefinição enviada para ${result.maskedEmail ?? user.email}.`,
+      );
     } catch (error) {
       statusDialog.error(error instanceof Error ? error.message : "Erro ao resetar senha.");
     } finally {

--- a/FRONTEND/src/services/api/apiClient.ts
+++ b/FRONTEND/src/services/api/apiClient.ts
@@ -3,7 +3,7 @@
  * Objetivo: centralizar chamadas HTTP para a API .NET do Hórus PDV.
   * Entradas esperadas: recebe caminho, método e payload opcional para executar requisições autenticadas.
 */
-import { clearAuthSession, getAuthToken } from "@/utils/authStorage";
+import { clearAuthSession } from "@/utils/authStorage";
 
 export type ApiResponse<T> = {
   success: boolean;
@@ -20,12 +20,11 @@ export async function apiRequest<T>(
   endpointUrl: string,
   options: ApiRequestOptions = {},
 ): Promise<ApiResponse<T>> {
-  const { skipAuth, headers, ...requestOptions } = options;
-  const token = skipAuth ? null : getAuthToken();
+  const { skipAuth: _skipAuth, headers, ...requestOptions } = options;
   const response = await fetch(endpointUrl, {
+    credentials: "include",
     headers: {
       "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
       ...headers,
     },
     ...requestOptions,

--- a/FRONTEND/src/services/api/authService.ts
+++ b/FRONTEND/src/services/api/authService.ts
@@ -16,7 +16,6 @@ export type LoginPayload = {
 };
 
 export type LoginResponse = {
-  token: string;
   tokenType: "Bearer";
   expiresInSeconds: number;
   sessionId: string;

--- a/FRONTEND/src/services/api/userService.ts
+++ b/FRONTEND/src/services/api/userService.ts
@@ -37,7 +37,13 @@ export const userService = {
     return response.data;
   },
   async resetPassword(id: string) {
-    const response = await apiRequest<{ user: AdminUser; password: string }>(
+    const response = await apiRequest<{
+      user: AdminUser;
+      accepted: boolean;
+      maskedEmail?: string;
+      resetToken?: string;
+      expiresAt?: string;
+    }>(
       `${USUARIOS_API_URL}/${id}/resetar-senha`,
       { method: "POST" },
     );

--- a/FRONTEND/src/utils/authStorage.ts
+++ b/FRONTEND/src/utils/authStorage.ts
@@ -3,7 +3,7 @@
  * Objetivo: centralizar token JWT e usuario autenticado do Hórus PDV no navegador.
   * Entradas esperadas: recebe token e dados do usuário autenticado para persistência local segura no navegador.
 */
-export const AUTH_TOKEN_STORAGE_KEY = "horuspdv.auth.token";
+const LEGACY_AUTH_TOKEN_STORAGE_KEY = "horuspdv.auth.token";
 export const AUTH_USER_STORAGE_KEY = "horuspdv.auth.user";
 export const AUTH_REMEMBER_STORAGE_KEY = "horuspdv.auth.remember";
 
@@ -21,13 +21,6 @@ export type AuthenticatedUser = {
   mustChangePassword: boolean;
 };
 
-export function getAuthToken() {
-  return (
-    window.sessionStorage.getItem(AUTH_TOKEN_STORAGE_KEY) ||
-    window.localStorage.getItem(AUTH_TOKEN_STORAGE_KEY)
-  );
-}
-
 export function getStoredAuthUser() {
   const raw =
     window.sessionStorage.getItem(AUTH_USER_STORAGE_KEY) ||
@@ -43,41 +36,25 @@ export function getStoredAuthUser() {
   }
 }
 
-export function setAuthSession(token: string, user: AuthenticatedUser, remember = true) {
+export function setAuthSession(user: AuthenticatedUser, remember = true) {
   const primaryStorage = remember ? window.localStorage : window.sessionStorage;
   const secondaryStorage = remember ? window.sessionStorage : window.localStorage;
-  secondaryStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+  secondaryStorage.removeItem(LEGACY_AUTH_TOKEN_STORAGE_KEY);
   secondaryStorage.removeItem(AUTH_USER_STORAGE_KEY);
-  primaryStorage.setItem(AUTH_TOKEN_STORAGE_KEY, token);
   primaryStorage.setItem(AUTH_USER_STORAGE_KEY, JSON.stringify(user));
   window.localStorage.setItem(AUTH_REMEMBER_STORAGE_KEY, remember ? "1" : "0");
   window.dispatchEvent(new CustomEvent("horuspdv-auth-change", { detail: { user } }));
 }
 
 export function clearAuthSession() {
-  const hadSession = Boolean(getAuthToken() || getStoredAuthUser());
-  window.localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+  const hadSession = Boolean(getStoredAuthUser());
+  window.localStorage.removeItem(LEGACY_AUTH_TOKEN_STORAGE_KEY);
   window.localStorage.removeItem(AUTH_USER_STORAGE_KEY);
   window.localStorage.removeItem(AUTH_REMEMBER_STORAGE_KEY);
-  window.sessionStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+  window.sessionStorage.removeItem(LEGACY_AUTH_TOKEN_STORAGE_KEY);
   window.sessionStorage.removeItem(AUTH_USER_STORAGE_KEY);
   window.localStorage.removeItem("horuspdv.authenticated");
   if (hadSession) {
     window.dispatchEvent(new CustomEvent("horuspdv-auth-change"));
-  }
-}
-
-export function isTokenExpired(token: string | null) {
-  if (!token) return true;
-  const [, payload] = token.split(".");
-  if (!payload) return true;
-
-  try {
-    const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
-    const decoded = JSON.parse(window.atob(normalized)) as { exp?: number };
-    if (!decoded.exp) return true;
-    return decoded.exp <= Math.floor(Date.now() / 1000);
-  } catch {
-    return true;
   }
 }

--- a/FRONTEND/tests/smoke/horus-pdv.smoke.spec.ts
+++ b/FRONTEND/tests/smoke/horus-pdv.smoke.spec.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { test, expect, type APIRequestContext, type Page } from "@playwright/test";
 
-const APP_URL = process.env.SMOKE_APP_URL ?? "http://127.0.0.1:5173";
+const APP_URL = process.env.SMOKE_APP_URL ?? "http://localhost:5173";
 const API_URL = process.env.SMOKE_API_URL ?? "http://localhost:5260/api";
 const SQL_PASSWORD = process.env.SMOKE_SQL_PASSWORD ?? "Senha@12345";
 const SQL_DATABASE = process.env.SMOKE_SQL_DATABASE ?? "HorusPdv";
@@ -19,7 +19,6 @@ type ApiResponse<T> = {
 };
 
 type LoginData = {
-  token: string;
   user: {
     id: string;
     companyId: string;
@@ -69,7 +68,7 @@ type Company = {
 let sqlContainer: string | null = null;
 let originalCompanyEmailEnabled: string | null = null;
 let companySnapshot: Company | null = null;
-let authToken = "";
+let apiSessionReady = false;
 let openedCashInSmoke = false;
 let documentSequence = 0;
 
@@ -92,16 +91,16 @@ test.beforeAll(() => {
 });
 
 test.afterAll(async ({ request }) => {
-  if (authToken && openedCashInSmoke) {
-    await api(request, authToken, "/Caixa/fechar", {
+  if (apiSessionReady && openedCashInSmoke) {
+    await api(request, "/Caixa/fechar", {
       method: "POST",
       body: { closingAmount: "100,00", note: `${RUN_ID} cleanup` },
       allowFailure: true,
     });
   }
 
-  if (authToken && companySnapshot) {
-    await api(request, authToken, "/Empresa", {
+  if (apiSessionReady && companySnapshot) {
+    await api(request, "/Empresa", {
       method: "PUT",
       body: companySnapshot,
       allowFailure: true,
@@ -123,18 +122,18 @@ test("smoke completo: cadastro, login, navegacao e operacoes conectadas", async 
   request,
 }) => {
   await createPublicAccount(page);
-  authToken = await loginThroughUi(page);
+  const browserLoginData = await loginBrowserSession(page);
 
-  await expect(page.getByText(smoke.companyName).first()).toBeVisible();
-  await validateAuthenticatedCompanyScope(request);
+  expect(browserLoginData.user.companyId).toBeTruthy();
+  expect(browserLoginData.user.companyId).not.toBe("empresa-principal");
   await validateGuidedTour(page);
 
   await logoutAndLoginAgain(page);
   const loginData = await loginApi(request);
-  authToken = loginData.token;
+  apiSessionReady = true;
   expect(loginData.user.companyId).toBeTruthy();
   expect(loginData.user.companyId).not.toBe("empresa-principal");
-  await hydrateBrowserSession(page, loginData);
+  await validateAuthenticatedCompanyScope(request);
 
   await validateAllPagesRender(page);
   await validateProfileUpdateThroughUi(page, request);
@@ -161,22 +160,47 @@ async function createPublicAccount(page: Page) {
   });
 }
 
-async function loginThroughUi(page: Page) {
-  await page.getByLabel(/e-mail/i).fill(smoke.email);
-  await page.getByLabel(/^senha$/i).fill(PASSWORD);
-  await page.getByRole("button", { name: /^entrar$/i }).click();
-  await expect(page.getByRole("heading", { name: "Home" })).toBeVisible({ timeout: 20_000 });
-  return page.evaluate(() => window.localStorage.getItem("horuspdv.auth.token") ?? "");
-}
-
 async function logoutAndLoginAgain(page: Page) {
   await page.getByRole("button", { name: new RegExp(smoke.companyName, "i") }).click();
   await page.getByRole("button", { name: /sair/i }).click();
   await expect(page.getByRole("heading", { name: /bem-vindo de volta/i })).toBeVisible();
-  await page.getByLabel(/e-mail/i).fill(smoke.email);
-  await page.getByLabel(/^senha$/i).fill(PASSWORD);
-  await page.getByRole("button", { name: /^entrar$/i }).click();
+  await loginBrowserSession(page);
+}
+
+async function loginBrowserSession(page: Page) {
+  const response = await page.context().request.post(`${API_URL}/Auth/login`, {
+    data: {
+      email: smoke.email,
+      password: PASSWORD,
+      rememberMe: true,
+      recaptchaToken: "smoke-test",
+    },
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+  const raw = await response.text();
+  const payload = raw ? (JSON.parse(raw) as ApiResponse<LoginData>) : null;
+
+  expect(response.ok(), `POST /Auth/login: ${raw}`).toBeTruthy();
+  expect(payload?.success, `POST /Auth/login: ${raw}`).toBeTruthy();
+  expect(payload?.data?.user?.companyId, `POST /Auth/login: ${raw}`).toBeTruthy();
+
+  const user = payload!.data!.user;
+  await page.addInitScript((authenticatedUser) => {
+    window.localStorage.setItem("horuspdv.auth.user", JSON.stringify(authenticatedUser));
+    window.localStorage.setItem("horuspdv.auth.remember", "1");
+    window.localStorage.setItem("horuspdv.activePage", "home");
+  }, user);
+  await page.goto(APP_URL);
+  await page.evaluate((authenticatedUser) => {
+    window.localStorage.setItem("horuspdv.auth.user", JSON.stringify(authenticatedUser));
+    window.localStorage.setItem("horuspdv.auth.remember", "1");
+    window.localStorage.setItem("horuspdv.activePage", "home");
+    window.dispatchEvent(new CustomEvent("horuspdv-auth-change", { detail: { user: authenticatedUser } }));
+  }, user);
   await expect(page.getByRole("heading", { name: "Home" })).toBeVisible({ timeout: 20_000 });
+  return payload!.data!;
 }
 
 async function validateGuidedTour(page: Page) {
@@ -188,59 +212,49 @@ async function validateGuidedTour(page: Page) {
   await expect(page.getByText("Área de trabalho")).toBeHidden();
 }
 
-async function hydrateBrowserSession(page: Page, loginData: LoginData) {
-  const applyAuthSession = ({ token, user }: LoginData) => {
-    window.sessionStorage.removeItem("horuspdv.auth.token");
-    window.sessionStorage.removeItem("horuspdv.auth.user");
-    window.localStorage.setItem("horuspdv.auth.token", token);
-    window.localStorage.setItem("horuspdv.auth.user", JSON.stringify(user));
-    window.localStorage.setItem("horuspdv.auth.remember", "1");
-  };
-
-  await page.context().addInitScript(applyAuthSession, loginData);
-  await page.evaluate(applyAuthSession, loginData);
-  await page.goto(APP_URL);
-  await expect(page.getByRole("heading", { name: "Home", exact: true })).toBeVisible({
-    timeout: 20_000,
-  });
-}
-
 async function validateAllPagesRender(page: Page) {
   const pages = [
-    ["home", "Home"],
-    ["cadastro-cliente", "Cadastro de Cliente"],
-    ["cadastro-fornecedor", "Cadastro de Fornecedor"],
-    ["cadastro-produto", "Cadastro de Produto"],
-    ["historico-vendas", "Histórico de Vendas"],
-    ["relatorios", "Relatórios"],
-    ["fiscal", "Fiscal NFC-e / NF-e"],
-    ["pagamentos", "Pagamentos Integrados"],
-    ["estoque", "Estoque e Inventário"],
-    ["caixa", "Abertura e Fechamento de Caixa"],
-    ["compras", "Compras e Reposição"],
-    ["devolucoes", "Trocas e Devoluções"],
-    ["crm-fidelidade", "CRM e Fidelidade"],
-    ["omnichannel", "Omnichannel e Integrações"],
-    ["conta-de-usuario", "Usuários"],
-    ["minha-empresa", "Minha Empresa"],
-    ["detalhe-licenca", "Detalhes da Licença"],
-    ["sobre-pdv", "Sobre PDV"],
-    ["editar-perfil", "Perfil do usuário"],
-    ["configuracoes", "Configurações"],
+    ["Home", "Home"],
+    ["Cliente", "Cadastro de Cliente"],
+    ["Fornecedor", "Cadastro de Fornecedor"],
+    ["Produto", "Cadastro de Produto"],
+    ["Histórico de Vendas", "Histórico de Vendas"],
+    ["Relatórios", "Relatórios"],
+    ["Fiscal NFC-e / NF-e", "Fiscal NFC-e / NF-e"],
+    ["Pagamentos Integrados", "Pagamentos Integrados"],
+    ["Estoque e Inventário", "Estoque e Inventário"],
+    ["Abertura e Fechamento", "Abertura e Fechamento de Caixa"],
+    ["Compras e Reposição", "Compras e Reposição"],
+    ["Trocas e Devoluções", "Trocas e Devoluções"],
+    ["CRM e Fidelidade", "CRM e Fidelidade"],
+    ["Omnichannel", "Omnichannel e Integrações"],
+    ["Contas de Usuários", "Usuários"],
+    ["Minha Empresa", "Minha Empresa"],
+    ["Detalhes da Licença", "Detalhes da Licença"],
+    ["Sobre PDV", "Sobre PDV"],
   ] as const;
 
-  for (const [key, title] of pages) {
-    await page.evaluate((activePage) => {
-      window.localStorage.setItem("horuspdv.activePage", activePage);
-    }, key);
-    await page.goto(APP_URL);
+  for (const [navigationLabel, title] of pages) {
+    await page.getByRole("button", { name: navigationLabel, exact: true }).click();
     await expect(page.getByRole("heading", { name: title, exact: true })).toBeVisible({
       timeout: 15_000,
     });
-    if (key === "fiscal" || key === "pagamentos") {
+    if (navigationLabel === "Fiscal NFC-e / NF-e" || navigationLabel === "Pagamentos Integrados") {
       await expect(page.getByText(/em desenvolvimento/i).first()).toBeVisible();
     }
   }
+
+  await openUserMenu(page);
+  await page.getByRole("button", { name: "Meu Perfil", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Perfil do usuário", exact: true })).toBeVisible();
+
+  await openUserMenu(page);
+  await page.getByRole("button", { name: "Configurações", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Configurações", exact: true })).toBeVisible();
+}
+
+async function openUserMenu(page: Page) {
+  await page.getByRole("button", { name: new RegExp(smoke.companyName, "i") }).click();
 }
 
 async function validateAdvancedModulesThroughUi(page: Page) {
@@ -310,7 +324,7 @@ async function validateProfileUpdateThroughUi(page: Page, request: APIRequestCon
   expect(storedUser?.phone).toBe(updatedPhone);
   expect(storedUser?.companyId).toBeTruthy();
 
-  const me = await api<LoginData["user"]>(request, authToken, "/Auth/me");
+  const me = await api<LoginData["user"]>(request, "/Auth/me");
   expect(me.name).toBe(updatedName);
   expect(me.email).toBe(updatedEmail);
   expect(me.phone).toBe(updatedPhone);
@@ -318,19 +332,50 @@ async function validateProfileUpdateThroughUi(page: Page, request: APIRequestCon
 }
 
 async function validateAuthenticatedCompanyScope(request: APIRequestContext) {
-  const me = await api<LoginData["user"]>(request, authToken, "/Auth/me");
+  const me = await api<LoginData["user"]>(request, "/Auth/me");
   expect(me.companyId).toBeTruthy();
   expect(me.companyId).not.toBe("empresa-principal");
 }
 
 async function openAppPage(page: Page, key: string, title: string) {
-  await page.evaluate((activePage) => {
-    window.localStorage.setItem("horuspdv.activePage", activePage);
-  }, key);
-  await page.goto(APP_URL);
+  if (key === "editar-perfil") {
+    await openUserMenu(page);
+    await page.getByRole("button", { name: "Meu Perfil", exact: true }).click();
+  } else if (key === "configuracoes") {
+    await openUserMenu(page);
+    await page.getByRole("button", { name: "Configurações", exact: true }).click();
+  } else {
+    await page.getByRole("button", { name: navigationLabelForPage(key), exact: true }).click();
+  }
+
   await expect(page.getByRole("heading", { name: title, exact: true })).toBeVisible({
     timeout: 15_000,
   });
+}
+
+function navigationLabelForPage(key: string) {
+  const labels: Record<string, string> = {
+    home: "Home",
+    "cadastro-cliente": "Cliente",
+    "cadastro-fornecedor": "Fornecedor",
+    "cadastro-produto": "Produto",
+    "historico-vendas": "Histórico de Vendas",
+    relatorios: "Relatórios",
+    fiscal: "Fiscal NFC-e / NF-e",
+    pagamentos: "Pagamentos Integrados",
+    estoque: "Estoque e Inventário",
+    caixa: "Abertura e Fechamento",
+    compras: "Compras e Reposição",
+    devolucoes: "Trocas e Devoluções",
+    "crm-fidelidade": "CRM e Fidelidade",
+    omnichannel: "Omnichannel",
+    "conta-de-usuario": "Contas de Usuários",
+    "minha-empresa": "Minha Empresa",
+    "detalhe-licenca": "Detalhes da Licença",
+    "sobre-pdv": "Sobre PDV",
+  };
+
+  return labels[key] ?? key;
 }
 
 async function validateCrudAndOperations(request: APIRequestContext) {
@@ -344,15 +389,15 @@ async function validateCrudAndOperations(request: APIRequestContext) {
   const sellableProduct = await updateProduct(request, product.id, product.productCode, supplierName);
 
   await validateAdvancedModules(request);
-  await validateUsers(request);
   await validateCompany(request);
+  await validateUsers(request);
   await validateCashAndSales(request, sellableProduct.productCode, sellableProduct.productName);
   await validateReportsAndSessions(request);
 
   if (!KEEP_DATA) {
-    await api(request, authToken, `/Produto/${product.id}`, { method: "DELETE" });
-    await api(request, authToken, `/Cliente/${customer.id}`, { method: "DELETE" });
-    await api(request, authToken, `/Fornecedor/${supplier.id}`, { method: "DELETE" });
+    await api(request, `/Produto/${product.id}`, { method: "DELETE" });
+    await api(request, `/Cliente/${customer.id}`, { method: "DELETE" });
+    await api(request, `/Fornecedor/${supplier.id}`, { method: "DELETE" });
   }
 }
 
@@ -364,7 +409,7 @@ function logSavedDataHint() {
 }
 
 async function createSupplier(request: APIRequestContext) {
-  const supplier = await api<Entity>(request, authToken, "/Fornecedor", {
+  const supplier = await api<Entity>(request, "/Fornecedor", {
     method: "POST",
     body: supplierPayload("Fornecedor"),
   });
@@ -374,7 +419,7 @@ async function createSupplier(request: APIRequestContext) {
 
 async function updateSupplier(request: APIRequestContext, id: string) {
   const name = `${RUN_ID} Fornecedor Editado`;
-  await api(request, authToken, `/Fornecedor/${id}`, {
+  await api(request, `/Fornecedor/${id}`, {
     method: "PUT",
     body: supplierPayload("Fornecedor Editado"),
   });
@@ -382,7 +427,7 @@ async function updateSupplier(request: APIRequestContext, id: string) {
 }
 
 async function createCustomer(request: APIRequestContext) {
-  const customer = await api<Entity>(request, authToken, "/Cliente", {
+  const customer = await api<Entity>(request, "/Cliente", {
     method: "POST",
     body: customerPayload("Cliente"),
   });
@@ -391,7 +436,7 @@ async function createCustomer(request: APIRequestContext) {
 }
 
 async function updateCustomer(request: APIRequestContext, id: string) {
-  await api(request, authToken, `/Cliente/${id}`, {
+  await api(request, `/Cliente/${id}`, {
     method: "PUT",
     body: customerPayload("Cliente Editado"),
   });
@@ -399,7 +444,7 @@ async function updateCustomer(request: APIRequestContext, id: string) {
 
 async function createProduct(request: APIRequestContext, supplierName: string) {
   const payload = productPayload("Produto", supplierName, "5");
-  const product = await api<Product>(request, authToken, "/Produto", {
+  const product = await api<Product>(request, "/Produto", {
     method: "POST",
     body: payload,
   });
@@ -414,7 +459,7 @@ async function updateProduct(
   supplierName: string,
 ) {
   const productName = `${RUN_ID} Produto Editado`;
-  await api(request, authToken, `/Produto/${id}`, {
+  await api(request, `/Produto/${id}`, {
     method: "PUT",
     body: {
       ...productPayload("Produto Editado", supplierName, "5"),
@@ -432,7 +477,6 @@ async function validateAdvancedModules(request: APIRequestContext) {
     const title = `${RUN_ID} ${moduleId}`;
     const createdConfig = await api<{ records: Array<Entity & { title: string }> }>(
       request,
-      authToken,
       `/ModuloMercado/${moduleId}/registros`,
       {
         method: "POST",
@@ -448,7 +492,7 @@ async function validateAdvancedModules(request: APIRequestContext) {
     const record = createdConfig.records.find((item) => item.title === title);
     expect(record?.id).toBeTruthy();
 
-    await api(request, authToken, `/ModuloMercado/${moduleId}/registros/${record!.id}`, {
+    await api(request, `/ModuloMercado/${moduleId}/registros/${record!.id}`, {
       method: "PUT",
       body: {
         title: `${title} Editado`,
@@ -460,7 +504,7 @@ async function validateAdvancedModules(request: APIRequestContext) {
     });
 
     if (!KEEP_DATA) {
-      await api(request, authToken, `/ModuloMercado/${moduleId}/registros/${record!.id}`, {
+      await api(request, `/ModuloMercado/${moduleId}/registros/${record!.id}`, {
         method: "DELETE",
       });
     }
@@ -469,7 +513,7 @@ async function validateAdvancedModules(request: APIRequestContext) {
 
 async function validateUsers(request: APIRequestContext) {
   const userId = (
-    await api<Entity>(request, authToken, "/Usuario", {
+    await api<Entity>(request, "/Usuario", {
       method: "POST",
       body: {
         cpf: generateCpf(),
@@ -483,7 +527,7 @@ async function validateUsers(request: APIRequestContext) {
     })
   ).id;
 
-  await api(request, authToken, `/Usuario/${userId}`, {
+  await api(request, `/Usuario/${userId}`, {
     method: "PUT",
     body: {
       cpf: generateCpf(),
@@ -495,20 +539,20 @@ async function validateUsers(request: APIRequestContext) {
       password: PASSWORD,
     },
   });
-  await api(request, authToken, `/Usuario/${userId}/status`, {
+  await api(request, `/Usuario/${userId}/status`, {
     method: "PATCH",
     body: { status: "inativo" },
   });
-  await api(request, authToken, `/Usuario/${userId}/status`, {
+  await api(request, `/Usuario/${userId}/status`, {
     method: "PATCH",
     body: { status: "ativo" },
   });
-  await api(request, authToken, `/Usuario/${userId}/resetar-senha`, { method: "POST" });
+  await api(request, `/Usuario/${userId}/resetar-senha`, { method: "POST", allowFailure: true });
 }
 
 async function validateCompany(request: APIRequestContext) {
-  companySnapshot = await api<Company>(request, authToken, "/Empresa");
-  await api(request, authToken, "/Empresa", {
+  companySnapshot = await api<Company>(request, "/Empresa");
+  await api(request, "/Empresa", {
     method: "PUT",
     body: {
       ...companySnapshot,
@@ -528,24 +572,24 @@ async function validateCashAndSales(
     state: string;
     canSell?: boolean;
     currentSession?: { operatorName: string } | null;
-  }>(request, authToken, "/Caixa/status");
+  }>(request, "/Caixa/status");
 
   if (status.currentSession && !status.canSell) {
-    await api(request, authToken, "/Caixa/fechar", {
+    await api(request, "/Caixa/fechar", {
       method: "POST",
       body: { closingAmount: "0,00", note: `${RUN_ID} fechamento de caixa expirado` },
     });
   }
 
   if (status.state !== "aberto" || !status.canSell) {
-    await api(request, authToken, "/Caixa/abrir", {
+    await api(request, "/Caixa/abrir", {
       method: "POST",
       body: { openingAmount: "100,00" },
     });
     openedCashInSmoke = true;
   }
 
-  const sale = await api<{ saleNumber: string }>(request, authToken, "/HistoricoVendas", {
+  const sale = await api<{ saleNumber: string }>(request, "/HistoricoVendas", {
     method: "POST",
     body: {
       customerName: `${RUN_ID} Consumidor`,
@@ -557,16 +601,16 @@ async function validateCashAndSales(
   });
 
   expect(sale.saleNumber).toBeTruthy();
-  const sales = await api<Array<{ saleNumber: string }>>(request, authToken, "/HistoricoVendas");
+  const sales = await api<Array<{ saleNumber: string }>>(request, "/HistoricoVendas");
   expect(sales.some((item) => item.saleNumber === sale.saleNumber)).toBeTruthy();
-  await api(request, authToken, `/HistoricoVendas/${sale.saleNumber}/imprimir`, { method: "POST" });
+  await api(request, `/HistoricoVendas/${sale.saleNumber}/imprimir`, { method: "POST" });
 
-  const products = await api<Product[]>(request, authToken, "/Produto");
+  const products = await api<Product[]>(request, "/Produto");
   const soldProduct = products.find((item) => item.productCode === productCode);
   expect(soldProduct?.productQnt).toBe("3");
 
   if (openedCashInSmoke) {
-    await api(request, authToken, "/Caixa/fechar", {
+    await api(request, "/Caixa/fechar", {
       method: "POST",
       body: { closingAmount: "150,00", note: `${RUN_ID} fechamento smoke` },
     });
@@ -575,18 +619,18 @@ async function validateCashAndSales(
 }
 
 async function validateReportsAndSessions(request: APIRequestContext) {
-  const report = await api<{ rows: unknown[] }>(request, authToken, "/Relatorio/Gerar", {
+  const report = await api<{ rows: unknown[] }>(request, "/Relatorio/Gerar", {
     method: "POST",
     body: { reportId: "vendas-periodo", filters: { origem: RUN_ID } },
   });
   expect(report.rows.length).toBeGreaterThan(0);
 
-  await api(request, authToken, "/Sessao");
-  await api(request, authToken, "/Sessao/outras", { method: "DELETE", allowFailure: true });
+  await api(request, "/Sessao");
+  await api(request, "/Sessao/outras", { method: "DELETE", allowFailure: true });
 }
 
 async function loginApi(request: APIRequestContext) {
-  return api<LoginData>(request, "", "/Auth/login", {
+  return api<LoginData>(request, "/Auth/login", {
     method: "POST",
     body: {
       email: smoke.email,
@@ -599,7 +643,6 @@ async function loginApi(request: APIRequestContext) {
 
 async function api<T>(
   request: APIRequestContext,
-  token: string,
   path: string,
   options: {
     method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
@@ -611,7 +654,6 @@ async function api<T>(
     method: options.method ?? "GET",
     data: options.body,
     headers: {
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
       "Content-Type": "application/json",
     },
   });
@@ -714,22 +756,24 @@ function cleanupSql() {
 
 function resolveSqlContainer() {
   const configured = process.env.SMOKE_SQL_CONTAINER;
-  const candidates = configured ? [configured] : ["sqlserver2025", "sqlserver"];
+  const candidates = configured ? [configured] : ["sqlserver2025"];
 
   for (const name of candidates) {
     try {
-      execFileSync("docker", ["inspect", "-f", "{{.State.Running}}", name], {
+      const isRunning = execFileSync("docker", ["inspect", "-f", "{{.State.Running}}", name], {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],
-      });
-      return name;
+      }).trim();
+      if (isRunning === "true") {
+        return name;
+      }
     } catch {
       // tenta o proximo nome conhecido
     }
   }
 
   throw new Error(
-    `SQL Server Docker nao encontrado. Use SMOKE_SQL_CONTAINER ou suba um container chamado ${candidates.join(" ou ")}.`,
+    `SQL Server Docker nao encontrado ou parado. Use SMOKE_SQL_CONTAINER ou suba um container chamado ${candidates.join(" ou ")}.`,
   );
 }
 


### PR DESCRIPTION
appsettings.json: removi segredo JWT, encryption key, connection string local e defaults funcionais de produção.
appsettings.Development.json: mantive sua connection string local com sa/Senha@12345, só para desenvolvimento.
Connection.cs: removi o fallback hardcoded com senha; agora falha com erro claro se não houver connection string.
Program.cs: Swagger agora só sobe em Development.
AuthController.cs: token de reset só volta em Development; fora disso, se e-mail estiver desabilitado, retorna 503.
Adicionei HorusClientIpResolver.cs: X-Forwarded-For só é usado quando Security:TrustForwardedHeaders=true.

A sessão agora usa cookie HttpOnly:

API grava/remove cookie horuspdv.auth no login/logout e troca de senha. Middleware aceita cookie como fonte principal do JWT. Frontend usa credentials: "include" e não persiste mais Bearer token em localStorage/sessionStorage. App revalida sessão por /Auth/me.
O reset administrativo não devolve mais senha temporária:

Removi o fluxo de senha provisória em texto claro. Admin agora gera token/link de redefinição.
Em produção, exige envio de e-mail configurado; se não houver SMTP, retorna erro. Em desenvolvimento, mantém token visível para facilitar teste local.