### PR TITLE
Fix missing Logging__LogLevel__Microsoft in appsettings.json

### DIFF
--- a/API/NETCORE/appsettings.json
+++ b/API/NETCORE/appsettings.json
@@ -36,8 +36,10 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
+      "Microsoft": "Warning",
       "Microsoft.AspNetCore": "Warning"
     }
   },
   "AllowedHosts": "*"
 }
+


### PR DESCRIPTION
## Problema
A build estava falhando com o erro: `failed to solve: secret Logging__LogLevel__Microsoft not found`

## Causa
O arquivo `appsettings.json` tinha apenas a configuração de logging para `Microsoft.AspNetCore`, mas o Railpack estava procurando por `Logging__LogLevel__Microsoft` (sem "AspNetCore").

## Solução
Adicionado a entrada `"Microsoft": "Warning"` na seção `Logging.LogLevel` do `appsettings.json`, alinhando com a configuração de `Microsoft.AspNetCore`.

## Mudanças
- `API/NETCORE/appsettings.json`: Adicionado `"Microsoft": "Warning"` à configuração de logging